### PR TITLE
feat: add card rotation and fix TTS import orientation

### DIFF
--- a/client/src/pages/GameTable.jsx
+++ b/client/src/pages/GameTable.jsx
@@ -5121,7 +5121,11 @@ export default function GameTable() {
                       className="flex flex-col items-center"
                     >
                       <div className="relative rounded-lg overflow-hidden border border-slate-600 hover:border-slate-400 transition-colors"
-                        style={{ width: 100, height: 140, backgroundColor: '#fff' }}>
+                        style={{
+                          width: (card.width > 0 && card.height > 0 && card.width > card.height) ? 140 : 100,
+                          height: (card.width > 0 && card.height > 0 && card.width > card.height) ? 100 : 140,
+                          backgroundColor: '#fff'
+                        }}>
                         {card.faceDown ? (
                           card.card_back_id && cardBackMap[card.card_back_id] ? (
                             <img src={cardBackMap[card.card_back_id]} alt="Card back" className="w-full h-full object-contain" />
@@ -5610,8 +5614,11 @@ export default function GameTable() {
               <div className="flex items-end justify-center" style={{ gap: '2px' }}>
                 {handCards.map((card, index) => {
                   const isMobile = window.innerWidth < 640;
-                  const cardWidth = isMobileLandscape ? 45 : (isMobile ? 60 : 80);
-                  const cardHeight = isMobileLandscape ? 63 : (isMobile ? 84 : 112);
+                  const isLandscapeCard = card.width > 0 && card.height > 0 && card.width > card.height;
+                  const baseW = isMobileLandscape ? 45 : (isMobile ? 60 : 80);
+                  const baseH = isMobileLandscape ? 63 : (isMobile ? 84 : 112);
+                  const cardWidth = isLandscapeCard ? baseH : baseW;
+                  const cardHeight = isLandscapeCard ? baseW : baseH;
                   const totalCards = handCards.length;
                   const spreadAngle = isMobileLandscape ? Math.min(2, 15 / totalCards) : (isMobile ? Math.min(3, 20 / totalCards) : Math.min(5, 30 / totalCards));
                   const centerIndex = (totalCards - 1) / 2;
@@ -5701,7 +5708,11 @@ export default function GameTable() {
         if (!card) return null;
         return (
           <div className="fixed z-50 pointer-events-none" data-testid="hand-card-preview" style={{ left: '50%', top: '50%', transform: 'translate(-50%, -70%)' }}>
-            <div className="rounded-xl overflow-hidden border-2 border-yellow-400 shadow-2xl shadow-black/50" style={{ width: 200, height: 280, backgroundColor: '#fff' }}>
+            <div className="rounded-xl overflow-hidden border-2 border-yellow-400 shadow-2xl shadow-black/50" style={{
+              width: (card.width > 0 && card.height > 0 && card.width > card.height) ? 280 : 200,
+              height: (card.width > 0 && card.height > 0 && card.width > card.height) ? 200 : 280,
+              backgroundColor: '#fff'
+            }}>
               {card.image_path ? (
                 <img src={card.image_path} alt={card.name} className="w-full h-full object-contain" />
               ) : (
@@ -5720,18 +5731,21 @@ export default function GameTable() {
       {draggingFromHand && (() => {
         const card = handCards.find(c => c.handId === draggingFromHand);
         if (!card) return null;
+        const ghostDims = (card.width > 0 && card.height > 0 && card.width > card.height)
+          ? { w: CARD_HEIGHT, h: CARD_WIDTH }
+          : { w: CARD_WIDTH, h: CARD_HEIGHT };
         return (
           <div
             className="fixed z-[70] pointer-events-none"
             data-testid="hand-drag-ghost"
             style={{
-              left: handDragPosition.x - CARD_WIDTH / 2,
-              top: handDragPosition.y - CARD_HEIGHT / 2,
+              left: handDragPosition.x - ghostDims.w / 2,
+              top: handDragPosition.y - ghostDims.h / 2,
             }}
           >
             <div
               className="rounded-lg overflow-hidden border-2 border-blue-400 shadow-2xl shadow-blue-400/50 opacity-70"
-              style={{ width: CARD_WIDTH, height: CARD_HEIGHT, backgroundColor: '#fff' }}
+              style={{ width: ghostDims.w, height: ghostDims.h, backgroundColor: '#fff' }}
             >
               {card.image_path ? (
                 <img src={card.image_path} alt={card.name} className="w-full h-full object-contain" />


### PR DESCRIPTION
Fixes #issue-8

## Summary

- Add rotate buttons (↺ CCW / ↻ CW) to each card in GameDetail for post-import orientation correction
- Add "Rotate imported cards" option to TTS import dialog (auto-detect, 90° CW/CW, 180°)
- New backend endpoint POST /api/games/:id/cards/:cardId/rotate to physically rotate card images
- Fix landscape card display in browse-stack, hand panel, hover-preview, drag-ghost

## Test plan

- [ ] Import TTS file with landscape cards, select "Auto-detect" rotation
- [ ] Verify landscape cards are correctly oriented after import
- [ ] Hover over a card in GameDetail and click rotate button
- [ ] Verify card image is rotated and aspect ratio updated
- [ ] Verify landscape cards display correctly in hand, preview, and browse stack

Generated with [Claude Code](https://claude.ai/code)