### PR TITLE
feat: add 1-player solo preset to ZoneEditor

### DIFF
--- a/client/src/components/ZoneEditor.jsx
+++ b/client/src/components/ZoneEditor.jsx
@@ -10,6 +10,12 @@ const PLAYER_COLORS = [
 ];
 
 const PRESET_LAYOUTS = {
+  '1p-solo': {
+    label: '1 Player – Solo',
+    zones: [
+      { color: 'blue', label: 'Player 1', x: 100, y: 300, width: 1000, height: 500 },
+    ],
+  },
   '2p-vertical': {
     label: '2 Players – Top/Bottom',
     zones: [


### PR DESCRIPTION
Adds a "1 Player – Solo" layout preset to the ZoneEditor so users can quickly configure a single player area for solo card games.

Closes #10

Generated with [Claude Code](https://claude.ai/code)