### PR TITLE
fix: improve camera scan card detection and mobile delete buttons

### DIFF
--- a/client/src/pages/GameDetail.jsx
+++ b/client/src/pages/GameDetail.jsx
@@ -1554,14 +1554,14 @@ export default function GameDetail() {
                             </svg>
                           </button>
                         </div>
-                        {/* Delete button (shown on hover) */}
+                        {/* Delete button (always visible on touch, hover on desktop) */}
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
                             handleDeleteCard(card.id, card.name);
                           }}
                           data-testid={`delete-card-${card.id}`}
-                          className="absolute top-1 right-1 p-1 bg-red-500 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity text-xs w-5 h-5 flex items-center justify-center"
+                          className="absolute top-1 right-1 p-1 bg-red-500 text-white rounded-full opacity-60 hover:opacity-100 transition-opacity text-xs w-5 h-5 flex items-center justify-center"
                           title="Delete card"
                         >
                           &times;
@@ -1633,7 +1633,7 @@ export default function GameDetail() {
                       <button
                         onClick={() => handleDeleteCardBack(cb.id, cb.name)}
                         data-testid={`delete-card-back-${cb.id}`}
-                        className="flex-shrink-0 w-5 h-5 flex items-center justify-center rounded text-red-400 opacity-0 group-hover:opacity-100 hover:bg-red-100 hover:text-red-600 transition-all text-xs"
+                        className="flex-shrink-0 w-5 h-5 flex items-center justify-center rounded text-red-400 opacity-60 hover:opacity-100 hover:bg-red-100 hover:text-red-600 transition-all text-xs"
                         title="Delete card back"
                       >
                         &times;

--- a/server/src/routes/card-backs.js
+++ b/server/src/routes/card-backs.js
@@ -2,9 +2,10 @@ import { v4 as uuidv4 } from 'uuid';
 import { getDb } from '../database.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { mkdirSync, existsSync, unlinkSync } from 'fs';
+import { mkdirSync, existsSync, unlinkSync, renameSync } from 'fs';
 import { pipeline } from 'stream/promises';
 import { createWriteStream } from 'fs';
+import sharp from 'sharp';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -72,6 +73,20 @@ export async function cardBacksRoutes(fastify) {
 
       // Save file to disk
       await pipeline(data.file, createWriteStream(filePath));
+
+      // Camera scan: auto-trim background so only the card back itself is kept.
+      if (request.query.is_camera_scan === 'true') {
+        try {
+          const trimmedPath = filePath + '.trimmed.jpg';
+          await sharp(filePath)
+            .trim({ threshold: 20 })
+            .jpeg({ quality: 92 })
+            .toFile(trimmedPath);
+          renameSync(trimmedPath, filePath);
+        } catch (trimErr) {
+          console.warn('[CardBacks] Camera scan trim failed, keeping original:', trimErr.message);
+        }
+      }
 
       // Derive card back name from original filename (without extension)
       const cardBackName = path.basename(data.filename, path.extname(data.filename));


### PR DESCRIPTION
Fixes #14

## Summary
- Improved camera scan detection: card must now fill the guide frame before auto-capture fires
- Added server-side background trim via sharp for camera-scanned images
- Made card and card-back delete buttons always visible (touch-accessible)

Generated with [Claude Code](https://claude.ai/code)